### PR TITLE
Fix: add variable to manage all the rotation/flip states(and reflect too)

### DIFF
--- a/src/lib/components/BlocksContainer.svelte
+++ b/src/lib/components/BlocksContainer.svelte
@@ -3,6 +3,11 @@
   import { gameStore } from "../../Store";
   import DraggableBlock from "./DraggableBlock.svelte";
 
+  // [TODO] refactor to display blocks based on blockState
+  let blockState: Map<BlockType, { rotation: number; flip: boolean }> = $state(
+    new Map(),
+  );
+
   const preset: Record<
     BlockType,
     ({ u: boolean; r: boolean; b: boolean; l: boolean } | null)[][]
@@ -200,7 +205,7 @@
 
 <div id="blocks-container">
   {#each $gameStore.unusedBlocks as block}
-    <DraggableBlock block={preset[block[0]]} type={block[0]} />
+    <DraggableBlock block={preset[block[0]]} type={block[0]} {blockState} />
   {/each}
 </div>
 

--- a/src/lib/components/DraggableBlock.svelte
+++ b/src/lib/components/DraggableBlock.svelte
@@ -17,14 +17,13 @@
 
   function handleDragStart(event: DragEvent) {
     if (!event.dataTransfer) return;
+    const state = blockState.get(type);
 
-    if ($moveStore === null) {
-      moveStore.set({
-        flip: false,
-        rotation: 0,
-        type,
-      });
-    }
+    moveStore.set({
+      type,
+      flip: state?.flip ?? false,
+      rotation: (state?.rotation ?? 0) as 0 | 1 | 2 | 3,
+    });
 
     event.dataTransfer.effectAllowed = "move";
 
@@ -55,19 +54,6 @@
 
   // [TODO] please refactor this stinky things
   function rotateBlock() {
-    moveStore.update((move) => {
-      if (move === null || move.type !== type)
-        return {
-          type,
-          flip: false,
-          rotation: 1,
-        };
-      return {
-        type,
-        flip: move.flip,
-        rotation: ((move.rotation + 1) % 4) as 0 | 1 | 2 | 3,
-      };
-    });
     const rotated = Array.from(Array(blockMatrix[0].length), () => {
       const newArr: ({
         u: boolean;
@@ -93,22 +79,22 @@
       });
     });
     blockMatrix = rotated;
+
+    const state = blockState.get(type);
+    if (state === undefined) {
+      blockState.set(type, {
+        rotation: 1,
+        flip: false,
+      });
+      return;
+    }
+    blockState.set(type, {
+      rotation: (state.rotation + 1) % 4,
+      flip: state.flip,
+    });
   }
 
   function flipBlock() {
-    moveStore.update((move) => {
-      if (move === null || move.type !== type)
-        return {
-          type,
-          flip: true,
-          rotation: 0,
-        };
-      return {
-        type,
-        flip: !move.flip,
-        rotation: move.rotation,
-      };
-    });
     blockMatrix = blockMatrix.reverse().map((blockLine) =>
       blockLine.map((cell) =>
         cell === null
@@ -120,6 +106,19 @@
             },
       ),
     );
+
+    const state = blockState.get(type);
+    if (state === undefined) {
+      blockState.set(type, {
+        rotation: 0,
+        flip: true,
+      });
+      return;
+    }
+    blockState.set(type, {
+      rotation: state.rotation,
+      flip: !state.flip,
+    });
   }
 </script>
 


### PR DESCRIPTION
The DnD feature was going wrong; especially after first DnD, variable for move preview was initialized unintentionally. Fixed that in this commit