### PR TITLE
Refactor: improve preview logics

### DIFF
--- a/src/lib/client/game/application/facade.ts
+++ b/src/lib/client/game/application/facade.ts
@@ -278,3 +278,5 @@ export class GameStateLayer implements
   }
   // ------------------------------------------------------------------------
 }
+
+export class GamePresentationLayer { }

--- a/src/lib/client/game/application/facade.ts
+++ b/src/lib/client/game/application/facade.ts
@@ -15,6 +15,8 @@ import { createNewBoard, getBlockMatrix, placeBlock } from '$lib/game/core';
 import type { IGameResultManager } from './ports/game-result.ports';
 import type { Score } from '$lib/domain/score';
 import type { IGameResultReader } from './ports/game-result-reader.ports';
+import type { IMoveConfirmationPresenter } from './ports/move-confirmation-presenter';
+import type { BoardPresentationManager } from '../ui/presentation';
 
 export class GameStateLayer implements
   IGameLifecycleManager,
@@ -279,4 +281,29 @@ export class GameStateLayer implements
   // ------------------------------------------------------------------------
 }
 
-export class GamePresentationLayer { }
+export class GamePresentationLayer implements IMoveConfirmationPresenter {
+  private boardPresentationManager: BoardPresentationManager;
+
+  get board() {
+    return this.boardPresentationManager;
+  }
+
+  constructor({
+    boardPresentationManager,
+  }: {
+    boardPresentationManager: BoardPresentationManager;
+  }) {
+    this.boardPresentationManager = boardPresentationManager;
+  }
+
+  // -----------------------MoveConfirmationPresenter------------------------
+  getConfirmPreviewData(p: {
+    board: BoardMatrix;
+    block: Block;
+    position: [number, number];
+    slotIdx: SlotIdx;
+  }): Promise<HTMLCanvasElement> {
+    return this.boardPresentationManager.getPreview(p);
+  }
+  // ------------------------------------------------------------------------
+}

--- a/src/lib/client/game/application/ports/move-confirmation-presenter.ts
+++ b/src/lib/client/game/application/ports/move-confirmation-presenter.ts
@@ -1,0 +1,10 @@
+import type { Block, BoardMatrix, SlotIdx } from "$types";
+
+export interface IMoveConfirmationPresenter {
+  getConfirmPreviewData: (p: {
+    board: BoardMatrix;
+    block: Block;
+    position: [number, number];
+    slotIdx: SlotIdx;
+  }) => Promise<HTMLCanvasElement>;
+}

--- a/src/lib/client/game/context.ts
+++ b/src/lib/client/game/context.ts
@@ -1,5 +1,5 @@
 import { setContext, getContext } from 'svelte';
-import type { GameStateLayer } from './application/facade';
+import type { GamePresentationLayer, GameStateLayer } from './application/facade';
 import type { GameManager } from './index';
 import { writable } from 'svelte/store';
 
@@ -8,10 +8,16 @@ const GAME_CTX_KEY = Symbol('GAME_CTX');
 export class GameContextContainer {
   state = writable<GameStateLayer | undefined>(undefined);
   actions = writable<GameManager | undefined>(undefined);
+  presentation = writable<GamePresentationLayer | undefined>(undefined);
 
-  initialize({ state, actions }: { state: GameStateLayer, actions: GameManager }) {
+  initialize({ state, actions, presentation }: {
+    state: GameStateLayer;
+    actions: GameManager;
+    presentation: GamePresentationLayer;
+  }) {
     this.state.set(state);
     this.actions.set(actions);
+    this.presentation.set(presentation);
   }
 }
 

--- a/src/lib/client/game/index.ts
+++ b/src/lib/client/game/index.ts
@@ -25,6 +25,7 @@ import {
 } from "./state";
 import type { Phase } from "./state/game";
 import { AlertManager, ConfirmManager, InputManager } from "./ui";
+import { GamePresentationLayer } from "./application/facade";
 
 export class GameManager {
   private eventBus: EventBus;
@@ -114,6 +115,8 @@ export class GameClientFactory {
       slotStateManager,
     });
 
+    const presentationLayer = new GamePresentationLayer();
+
     const turnSequencer = new TurnSequencer();
     const turnTimer = new PlayerTurnTimer({ eventBus });
 
@@ -185,6 +188,6 @@ export class GameClientFactory {
 
     const gameManager = new GameManager({ eventBus });
 
-    return { gameManager, stateLayer };
+    return { gameManager, stateLayer, presentationLayer };
   }
 }

--- a/src/lib/client/game/index.ts
+++ b/src/lib/client/game/index.ts
@@ -164,6 +164,8 @@ export class GameClientFactory {
       slotManager: stateLayer,
       turnManager: stateLayer,
       boardReader: stateLayer,
+
+      moveConfirmationPresenter: presentationLayer,
     });
     new PregameOrchestrator({
       eventBus,

--- a/src/lib/client/game/index.ts
+++ b/src/lib/client/game/index.ts
@@ -51,18 +51,16 @@ export class GameManager {
   }
 
   submitMove({
-    previewUrl,
     position,
     blockInfo,
     slotIdx,
   }: {
-    previewUrl: string;
     position: [number, number];
     blockInfo: Block;
     slotIdx: SlotIdx;
   }) {
     this.eventBus.publish('PlayerMoveSubmitted', {
-      previewUrl, position, blockInfo, slotIdx,
+      position, blockInfo, slotIdx,
     });
   }
 

--- a/src/lib/client/game/index.ts
+++ b/src/lib/client/game/index.ts
@@ -26,6 +26,7 @@ import {
 import type { Phase } from "./state/game";
 import { AlertManager, ConfirmManager, InputManager } from "./ui";
 import { GamePresentationLayer } from "./application/facade";
+import { BoardPresentationManager } from "./ui/presentation";
 
 export class GameManager {
   private eventBus: EventBus;
@@ -115,7 +116,10 @@ export class GameClientFactory {
       slotStateManager,
     });
 
-    const presentationLayer = new GamePresentationLayer();
+    const boardPresentationManager = new BoardPresentationManager();
+    const presentationLayer = new GamePresentationLayer({
+      boardPresentationManager,
+    });
 
     const turnSequencer = new TurnSequencer();
     const turnTimer = new PlayerTurnTimer({ eventBus });

--- a/src/lib/client/game/orchestrator/PlayerTurn.ts
+++ b/src/lib/client/game/orchestrator/PlayerTurn.ts
@@ -150,7 +150,7 @@ export class PlayerTurnOrchestrator {
         console.warn('move is duplicated or delayed');
         return;
       }
-      const { blockInfo, position, slotIdx, previewUrl } = event.payload;
+      const { blockInfo, position, slotIdx } = event.payload;
       const playerIdx = this.clientInfoReader.getClientPlayerIdx();
       const turn = this.turnManager.getCurrentTurn();
       const { result, reason } = this.moveApplier.checkBlockPlaceability({

--- a/src/lib/client/game/orchestrator/PlayerTurn.ts
+++ b/src/lib/client/game/orchestrator/PlayerTurn.ts
@@ -161,6 +161,13 @@ export class PlayerTurnOrchestrator {
         return;
       }
 
+      const board = this.boardReader.getBoard();
+      if (!board) {
+        throw new Error('Board is not initialized');
+      }
+      const movePreviewElement = await this.moveConfirmationPresenter.getConfirmPreviewData({
+        block: blockInfo, board, position, slotIdx,
+      });
       switch (this.turnState) {
         case 'NOT_PLAYER_TURN': {
           // [TODO] reserve move here
@@ -168,7 +175,8 @@ export class PlayerTurnOrchestrator {
         }
         case 'PLAYER_TURN': {
           this.setState('MOVE_PROCESSING');
-          const result = await this.confirmManager.openMoveConfirmModal(previewUrl);
+          // [TODO] cast the type if needed
+          const result = await this.confirmManager.openMoveConfirmModal(movePreviewElement.toDataURL());
           if (result === 'CONFIRM') {
             const moveMessage: InboundMoveMessage = {
               type: 'MOVE',

--- a/src/lib/client/game/orchestrator/PlayerTurn.ts
+++ b/src/lib/client/game/orchestrator/PlayerTurn.ts
@@ -1,6 +1,7 @@
 import type { InboundMoveMessage, InboundSkipTurnMessage, SubmitMoveDTO } from "$types";
 import type { IClientInfoReader, IMoveApplier, ISlotManager, ITurnManager } from "../application/ports";
 import type { IBoardReader } from "../application/ports/board-reader.ports";
+import type { IMoveConfirmationPresenter } from "../application/ports/move-confirmation-presenter";
 import type { EventBus } from "../event";
 import type { PlayerTurnTimer } from "../sequence/timer";
 import type { AlertManager, ConfirmManager } from "../ui/handler/Dialog";
@@ -31,6 +32,8 @@ export class PlayerTurnOrchestrator {
   private clientInfoReader: IClientInfoReader;
   private boardReader: IBoardReader;
 
+  private moveConfirmationPresenter: IMoveConfirmationPresenter;
+
   private turnState: TurnState = 'NOT_PLAYER_TURN';
 
   constructor({
@@ -43,6 +46,7 @@ export class PlayerTurnOrchestrator {
     moveApplier,
     clientInfoReader,
     boardReader,
+    moveConfirmationPresenter,
   }: {
     eventBus: EventBus;
     playerTurnTimer: PlayerTurnTimer;
@@ -53,6 +57,7 @@ export class PlayerTurnOrchestrator {
     moveApplier: IMoveApplier;
     clientInfoReader: IClientInfoReader;
     boardReader: IBoardReader;
+    moveConfirmationPresenter: IMoveConfirmationPresenter;
   }) {
     this.eventBus = eventBus;
     this.playerTurnTimer = playerTurnTimer;
@@ -63,6 +68,7 @@ export class PlayerTurnOrchestrator {
     this.moveApplier = moveApplier;
     this.clientInfoReader = clientInfoReader;
     this.boardReader = boardReader;
+    this.moveConfirmationPresenter = moveConfirmationPresenter;
 
     this.eventBus.subscribe('PlayerTurnStarted', (event) => {
       const { slotIdx, lastMoveTimestamp } = event.payload;

--- a/src/lib/client/game/ui/presentation/Board.ts
+++ b/src/lib/client/game/ui/presentation/Board.ts
@@ -1,0 +1,82 @@
+import { getBlockMatrix } from "$lib/game/core";
+import type { Block, BoardMatrix, CellValue, SlotIdx } from "$types";
+import { readable, writable, type Readable, type Writable } from "svelte/store";
+import { uuidv7 } from "uuidv7";
+
+type RequestId = string;
+
+export type PreviewRequest = {
+  id: RequestId;
+  matrix: Readable<BoardMatrix>;
+  resolve: (result: HTMLCanvasElement) => void;
+};
+
+export class BoardPresentationManager {
+  private _previewRequest: Writable<PreviewRequest | null>;
+  get previewRequest() { return { subscribe: this._previewRequest.subscribe }; }
+
+  constructor() {
+    this._previewRequest = writable(null);
+  }
+
+  async getPreview(p: {
+    board: BoardMatrix;
+    block: Block;
+    position: [number, number];
+    slotIdx: SlotIdx;
+  }): Promise<HTMLCanvasElement> {
+    const matrix = this._calculatePreviewMatrix(p);
+    const requestId = uuidv7();
+
+    // [TODO] add timeout
+    const promise = new Promise<HTMLCanvasElement>((res) => {
+      this._previewRequest.set({ id: requestId, matrix: readable(matrix), resolve: res });
+    });
+
+    const element = await promise;
+    return element;
+  }
+
+  private _calculatePreviewMatrix({
+    board,
+    block,
+    position,
+    slotIdx,
+  }: {
+    board: BoardMatrix;
+    block: Block;
+    position: [number, number];
+    slotIdx: SlotIdx;
+  }): BoardMatrix {
+    const blockMatrix = getBlockMatrix(block);
+
+    const blockHeight = blockMatrix.length;
+    const blockWidth = blockMatrix[0].length;
+
+    const startRow = Math.max(0, position[0] - 2);
+    const startCol = Math.max(0, position[1] - 2);
+    const endRow = Math.min(19, position[0] + blockHeight + 1);
+    const endCol = Math.min(19, position[1] + blockWidth + 1);
+
+    const previewMatrix: BoardMatrix = [];
+    for (let i = startRow; i <= endRow; i += 1) {
+      const row: CellValue[] = [];
+      for (let j = startCol; j <= endCol; j += 1) {
+        let cell = board[i][j];
+        if (
+          i >= position[0] &&
+          i < position[0] + blockHeight &&
+          j >= position[1] &&
+          j < position[1] + blockWidth &&
+          blockMatrix[i - position[0]][j - position[1]]
+        ) {
+          cell = slotIdx;
+        }
+        row.push(cell);
+      }
+      previewMatrix.push(row);
+    }
+
+    return previewMatrix;
+  }
+}

--- a/src/lib/client/game/ui/presentation/index.ts
+++ b/src/lib/client/game/ui/presentation/index.ts
@@ -1,0 +1,3 @@
+import { BoardPresentationManager } from './Board';
+
+export { BoardPresentationManager };

--- a/src/lib/components/Board.svelte
+++ b/src/lib/components/Board.svelte
@@ -45,9 +45,11 @@
   function highlightCells({
     block,
     position,
+    boardElement,
   }: {
     block: BlockMatrix;
     position: number[];
+    boardElement: HTMLElement;
   }) {
     unhighlightCells();
     if (
@@ -69,7 +71,15 @@
     }
   }
 
-  function getPosition({ x, y }: { x: number; y: number }): [number, number] {
+  function getPosition({
+    x,
+    y,
+    boardElement,
+  }: {
+    x: number;
+    y: number;
+    boardElement: HTMLElement;
+  }): [number, number] {
     const { left: boardLeft, top: boardTop } =
       boardElement.getBoundingClientRect();
     return [
@@ -78,19 +88,20 @@
     ];
   }
 
-  function handleDragOver(e: DragEvent, rowIdx: number, colIdx: number) {
+  function handleDragOver(e: DragEvent, boardElement: HTMLElement) {
     e.preventDefault();
     if ($moveStore === null) return;
     highlightCells({
       block: getBlockMatrix($moveStore),
-      position: getPosition({ x: e.clientX, y: e.clientY }),
+      position: getPosition({ x: e.clientX, y: e.clientY, boardElement }),
+      boardElement,
     });
   }
 
-  async function handleDrop(e: DragEvent, rowIdx: number, colIdx: number) {
+  async function handleDrop(e: DragEvent, boardElement: HTMLElement) {
     e.preventDefault();
 
-    const position = getPosition({ x: e.clientX, y: e.clientY });
+    const position = getPosition({ x: e.clientX, y: e.clientY, boardElement });
 
     dragPositionOffsetStore.set([0, 0]);
     highlightedCells.forEach((e) => {
@@ -109,6 +120,7 @@
         getBlockMatrix({ type, rotation, flip }),
         position as [number, number],
         slotIdx,
+        boardElement,
       );
       submitMove({
         previewUrl: capturedImageURL,
@@ -126,6 +138,7 @@
     block: BlockMatrix,
     position: [number, number],
     slotIdx: SlotIdx,
+    boardElement: HTMLElement,
   ): Promise<string> {
     const blockHeight = block.length;
     const blockWidth = block[0].length;
@@ -187,10 +200,10 @@
             role="button"
             tabindex="0"
             ondragover={(e) => {
-              handleDragOver(e, rowIdx, colIdx);
+              handleDragOver(e, boardElement);
             }}
             ondrop={(e) => {
-              handleDrop(e, rowIdx, colIdx);
+              handleDrop(e, boardElement);
             }}
           ></div>
         </div>

--- a/src/lib/components/Board.svelte
+++ b/src/lib/components/Board.svelte
@@ -10,7 +10,6 @@
     submitMove,
   }: {
     submitMove: (param: {
-      previewUrl: string;
       position: [number, number];
       blockInfo: Block;
       slotIdx: SlotIdx;
@@ -115,14 +114,7 @@
         throw new Error("missing blockInfo");
       }
 
-      const capturedImageURL = await capturePartialBoard(
-        getBlockMatrix({ type, rotation, flip }),
-        position as [number, number],
-        slotIdx,
-        boardElement,
-      );
       submitMove({
-        previewUrl: capturedImageURL,
         position,
         blockInfo: { type, rotation, flip },
         slotIdx,

--- a/src/lib/components/Board.svelte
+++ b/src/lib/components/Board.svelte
@@ -4,6 +4,7 @@
   import { dragPositionOffsetStore, moveStore } from "$lib/store";
   import html2canvas from "html2canvas";
   import { useGame } from "$lib/client/game/context";
+  import BoardMatrixRenderer from "./BoardMatrixRenderer.svelte";
 
   const {
     submitMove,
@@ -18,8 +19,6 @@
 
   const { state } = useGame();
   const boardStore = $state?.board.matrix;
-
-  let boardElement: HTMLElement;
 
   class CellHighlightManager {
     // [TODO] implement this class for optimization:
@@ -189,71 +188,4 @@
   }
 </script>
 
-<div id="board" bind:this={boardElement}>
-  {#each $boardStore as boardLine, rowIdx}
-    <div id="boardLine-{rowIdx}" class="boardLine">
-      {#each boardLine as cell, colIdx}
-        <div class="cell-cover">
-          <div
-            id="cell-{rowIdx}-{colIdx}"
-            class="cell cell-{cell}"
-            role="button"
-            tabindex="0"
-            ondragover={(e) => {
-              handleDragOver(e, boardElement);
-            }}
-            ondrop={(e) => {
-              handleDrop(e, boardElement);
-            }}
-          ></div>
-        </div>
-      {/each}
-    </div>
-  {/each}
-</div>
-
-<style>
-  #board {
-    width: fit-content;
-    height: fit-content;
-    background: white;
-    border: 0.5px solid black;
-  }
-  .boardLine {
-    display: flex;
-    flex-direction: row;
-  }
-  .cell-cover {
-    background: white;
-    padding: 1px;
-    border-left: 0.5px solid rgba(0, 0, 0, 0.267);
-    border-bottom: 0.5px solid rgba(0, 0, 0, 0.267);
-  }
-  .cell-cover:first-child {
-    border-left: none;
-  }
-  #boardLine-19 > .cell-cover {
-    border-bottom: none;
-  }
-  .cell {
-    width: 30px;
-    height: 30px;
-    background: rgb(185, 185, 185);
-  }
-  .cell-0 {
-    background: rgba(0, 0, 255, 0.625);
-  }
-  .cell-1 {
-    background: rgba(255, 0, 0, 0.65);
-  }
-  .cell-2 {
-    background: rgb(0, 220, 0, 0.625);
-  }
-  .cell-3 {
-    background: rgb(255, 255, 0, 0.75);
-  }
-  .highlighted {
-    /* change to other color */
-    background: black !important;
-  }
-</style>
+<BoardMatrixRenderer source={boardStore} {handleDragOver} {handleDrop} />

--- a/src/lib/components/BoardMatrixRenderer.svelte
+++ b/src/lib/components/BoardMatrixRenderer.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import type { BoardMatrix } from "$types";
+  import type { Readable } from "svelte/store";
+
+  let boardElement: HTMLElement;
+
+  let {
+    source,
+    handleDragOver,
+    handleDrop,
+  }: {
+    source: Readable<BoardMatrix> | undefined;
+    handleDragOver:
+      | undefined
+      | ((e: DragEvent, boardElement: HTMLElement) => void);
+    handleDrop: undefined | ((e: DragEvent, boardElement: HTMLElement) => void);
+  } = $props();
+</script>
+
+<div class="board" bind:this={boardElement}>
+  {#each $source as boardLine, rowIdx}
+    <div id="boardLine-{rowIdx}" class="boardLine">
+      {#each boardLine as cell, colIdx}
+        <div class="cell-cover">
+          <div
+            id="cell-{rowIdx}-{colIdx}"
+            class="cell cell-{cell}"
+            role="button"
+            tabindex="0"
+            ondragover={(e) => {
+              handleDragOver?.(e, boardElement);
+            }}
+            ondrop={(e) => {
+              handleDrop?.(e, boardElement);
+            }}
+          ></div>
+        </div>
+      {/each}
+    </div>
+  {/each}
+</div>
+
+<style>
+  .board {
+    width: fit-content;
+    height: fit-content;
+    background: white;
+    border: 0.5px solid black;
+  }
+  .boardLine {
+    display: flex;
+    flex-direction: row;
+  }
+  .cell-cover {
+    background: white;
+    padding: 1px;
+    border-left: 0.5px solid rgba(0, 0, 0, 0.267);
+    border-bottom: 0.5px solid rgba(0, 0, 0, 0.267);
+  }
+  .cell-cover:first-child {
+    border-left: none;
+  }
+  #boardLine-19 > .cell-cover {
+    border-bottom: none;
+  }
+  .cell {
+    width: 30px;
+    height: 30px;
+    background: rgb(185, 185, 185);
+  }
+  .cell-0 {
+    background: rgba(0, 0, 255, 0.625);
+  }
+  .cell-1 {
+    background: rgba(255, 0, 0, 0.65);
+  }
+  .cell-2 {
+    background: rgb(0, 220, 0, 0.625);
+  }
+  .cell-3 {
+    background: rgb(255, 255, 0, 0.75);
+  }
+  .highlighted {
+    /* change to other color */
+    background: black !important;
+  }
+</style>

--- a/src/lib/components/BoardMatrixRenderer.svelte
+++ b/src/lib/components/BoardMatrixRenderer.svelte
@@ -10,10 +10,12 @@
     handleDrop,
   }: {
     source: Readable<BoardMatrix> | undefined;
-    handleDragOver:
+    handleDragOver?:
       | undefined
       | ((e: DragEvent, boardElement: HTMLElement) => void);
-    handleDrop: undefined | ((e: DragEvent, boardElement: HTMLElement) => void);
+    handleDrop?:
+      | undefined
+      | ((e: DragEvent, boardElement: HTMLElement) => void);
   } = $props();
 </script>
 

--- a/src/lib/components/OffscreenBoardSnapshot.svelte
+++ b/src/lib/components/OffscreenBoardSnapshot.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { useGame } from "$lib/client/game/context";
+  import { tick } from "svelte";
+  import BoardMatrixRenderer from "./BoardMatrixRenderer.svelte";
+  import html2canvas from "html2canvas";
+  import type { PreviewRequest } from "$lib/client/game/ui/presentation/Board";
+
+  const { presentation } = useGame();
+  const previewRequest = $presentation?.board.previewRequest;
+  let snapshotElement: HTMLElement;
+  let lastReq = $state<PreviewRequest | null>(null);
+
+  const handlePreviewRequest = (request: PreviewRequest | null) => {
+    if (request && request?.id !== lastReq?.id) {
+      lastReq = request;
+      processSnapshot(request);
+    }
+  };
+
+  const processSnapshot = async (request: PreviewRequest) => {
+    if (!snapshotElement) {
+      return;
+    }
+    await tick();
+
+    const canvas = await html2canvas(snapshotElement, {
+      backgroundColor: null,
+      logging: false,
+    });
+
+    request.resolve(canvas);
+  };
+
+  previewRequest?.subscribe((req) => handlePreviewRequest(req));
+</script>
+
+<div
+  bind:this={snapshotElement}
+  style="position: absolute; left: -9999px; top: -9999px;"
+>
+  {#if lastReq}
+    <BoardMatrixRenderer source={lastReq.matrix} />
+  {/if}
+</div>

--- a/src/lib/types/client/event/payload.ts
+++ b/src/lib/types/client/event/payload.ts
@@ -25,7 +25,6 @@ export type BlockNotPlaceablePayload = {
 }
 
 export type PlayerMoveSubmittedPayload = {
-  previewUrl: string;
   position: [number, number];
   blockInfo: Block;
   slotIdx: SlotIdx;

--- a/src/routes/rooms/[room_id]/+page.svelte
+++ b/src/routes/rooms/[room_id]/+page.svelte
@@ -91,7 +91,6 @@
   });
 
   const submitMove = (param: {
-    previewUrl: string;
     position: [number, number];
     blockInfo: Block;
     slotIdx: SlotIdx;

--- a/src/routes/rooms/[room_id]/+page.svelte
+++ b/src/routes/rooms/[room_id]/+page.svelte
@@ -58,16 +58,21 @@
     );
     worker = new workerModule.default();
     const players = [roomCache.p0, roomCache.p1, roomCache.p2, roomCache.p3];
-    const { stateLayer } = ({ gameManager } = GameClientFactory.create({
-      webWorker: worker,
-      webSocket: socket,
+    const { stateLayer, presentationLayer } = ({ gameManager } =
+      GameClientFactory.create({
+        webWorker: worker,
+        webSocket: socket,
 
-      context: {
-        playerIdx: playerIdx as PlayerIdx,
-        players,
-      },
-    }));
-    gameContext.initialize({ state: stateLayer, actions: gameManager });
+        context: {
+          playerIdx: playerIdx as PlayerIdx,
+          players,
+        },
+      }));
+    gameContext.initialize({
+      state: stateLayer,
+      actions: gameManager,
+      presentation: presentationLayer,
+    });
     isGameInitialized = true;
 
     // [TODO] to prevent initializing error, add condition for single player game(prevent to start game)

--- a/src/routes/rooms/[room_id]/+page.svelte
+++ b/src/routes/rooms/[room_id]/+page.svelte
@@ -10,6 +10,7 @@
   import type { Block, BoardMatrix, PlayerIdx, SlotIdx } from "$types";
   import type { PageData } from "./$types";
   import { createGameContext } from "$lib/client/game/context";
+  import OffscreenBoardSnapshot from "$lib/components/OffscreenBoardSnapshot.svelte";
 
   const { data }: { data: PageData } = $props();
   const { room, playerIdx, roomCache, moves } = data;
@@ -104,6 +105,7 @@
 </script>
 
 {#if isGameInitialized}
+  <OffscreenBoardSnapshot></OffscreenBoardSnapshot>
   <Players
     ready={() => {
       gameManager.submitReady();


### PR DESCRIPTION
# Overview

This PR contains refactoring of the move confirmation preview logic, moving it away from the tight coupling with the interactive `Board.svelte` component. Previously, the preview image was generated by capturing the live DOM of the board directly within the UI component, which included potential visual artifacts and mixed concerns and caused force re-rendering by manipulating DOM directly(especially `document.body`)`.

The new implementation introduces a presentation layer to the game client architecture. The preview image is now generated by calculating the future board state(Pure Data), rendering it off-screen using a dedicated renderer, and capturing it asynchronously. This ensures that the game logic of orch relies on a stable, data-driven interface for UI generation rather than passing image blobs through the event bus.

# Architectural Changes

## Presentation Layer (`GamePresentationLayer` - `BoardPresentationManager`)

- Introduced `GamePresentationLayer` as the facade for UI-related logic, implementing the new `IMoveConfirmationPresenter` port.
- `BoardPresentationManager` is responsible for deriving the "Preview Matrix(the hypothetical state of the board after a move)" purely from data, separating the visual calculation from the active game state.

## Port(`IMoveConfirmationPresenter`)

- Defined `IMoveConfirmationPresenter` to decouple the `PlayerTurnOrchestrator` from the specific method of generating preview images. The Orchestrator now requests a preview via this interface instead of receiving a `previewUrl` from the UI event payload.

# Key Implementation Details

## Off-screen Snapshot Architecture

- `OffscreenBoardSnapshot.svelte`: A new component responsible for rendering the calculated preview matrix in an invisible area and capturing it via html2canvas.
- Request-Resolve Pattern: Implemented an uuid-based request mechanism using Svelte stores (by `._previewRequest`). The `BoardPresentationManager` dispatches a request with the calculated matrix, and the Svelte component processes it and resolves the Promise with the generated `HTMLCanvasElement`.

## Component Extraction(`BoardMatrixRenderer`)

- Extracted the core board rendering logic into `BoardMatrixRenderer.svelte`.
- This component is now reused by both the main interactive `Board.svelte`(which is for the game) and `OffscreenBoardSnapshot.svelte`(for image generation), ensuring visual consistency while allowing different behaviors (interactive <-> static).

## Orchestrator & Flow Updates

- `PlayerTurnOrchestrator`: Now explicitly calls `MoveConfirmationPresenter.getConfirmPreviewData` to generate the preview before opening the confirmation modal.
- `GameManager` and else: Removed previewUrl from the submitMove payload. The UI no longer bears the responsibility of generating the snapshot before submission; it only submits the move intent (position, block, slot).

# Benefits
- Clean Separation: The "Game Logic" no longer depends on the **view's current DOM state**.
- Visual Consistency: The preview is guaranteed to be a clean representation of the move, free from hover effects, drag ghosts, or other UI artifacts present on the live board.
- Reusability: BoardMatrixRenderer simplifies the main `Board` component and allows for flexible rendering of board states anywhere in the app.

# Remarks
- Modification of `BoardPresentationManager` is needed for merging to branch `refactor/ui` since the implementation of preview presentation logics and `Board.svelte`(and else) are quite different.
